### PR TITLE
Stop waiting if workflow has been superseded

### DIFF
--- a/lib/Clock.ts
+++ b/lib/Clock.ts
@@ -3,20 +3,18 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
 class Clock {
-  async setTimeoutWithLogging(timeoutInMs: number, interval: number, message: (timeElapsed: number, timeRemaining: number) => void) {
-    let loggerInterval;
+  async setTimeoutWithLogging(timeoutInMs: number, interval: number, message: (timeElapsed: number, timeRemaining: number) => boolean) {
     let timeElapsed = 0;
+    let should_continue = true;
 
-    loggerInterval = setInterval(() => {
-      timeElapsed = timeElapsed + interval;
+    while (should_continue && timeElapsed < timeoutInMs) {
+      await this.setTimeout(interval)
+
+      timeElapsed += interval;
       const timeRemaining = timeoutInMs - timeElapsed;
 
-      message(timeElapsed, timeRemaining);
-    }, interval);
-
-    await this.setTimeout(timeoutInMs)
-
-    clearInterval(loggerInterval);
+      should_continue = message(timeElapsed, timeRemaining);
+    }
   }
 
   async setTimeout(timeout: number) {


### PR DESCRIPTION
This change is helpful for longer wait intervals, for example 30 minutes, by checking if the workflow has been superseded at least every minute (and at most every second, for smaller intervals), and stop waiting if it has.

I'm using this action as part of the deploy workflow to wait for 30 minutes between different deployment targets.

Thanks for the good work on this action!